### PR TITLE
feat: implement null count built in metric

### DIFF
--- a/BUILTIN_METRICS.md
+++ b/BUILTIN_METRICS.md
@@ -1,0 +1,17 @@
+# Built-in Metrics
+
+This Document describe the built-in metrics that are available in the library.
+
+## Metrics
+
+| Metric Name                | Available | Description                                                                                            | Comment |
+|----------------------------|-----------|--------------------------------------------------------------------------------------------------------|---------|
+| Null count                 | Yes       | Counts the number of null records in a dataset given a column.                                         |         |
+| Null count over window     | No        | Counts the number of null records within a specified window of time in the dataset given a column.     |         |
+| Non null count             | No        | Counts the number of non-null records in a dataset given a column.                                     |         |
+| Non null count over window | No        | Counts the number of non-null records within a specified window of time in the dataset given a column. |         |
+| Total count                | No        | Counts the total number of records in a dataset.                                                       |         |
+| Total count over window    | No        | Counts the total number of records within a specified window of time in the dataset.                   |         |
+| Count distinct             | No        | Counts the number of distinct records in a dataset given a set of columns.                             |         |
+| Count duplicate            | No        | Counts the number of duplicate records in a dataset given a set of columns.                            |         |
+| z-score                    | No        | Calculates the z-score for records in a dataset given a column.                                        |         |

--- a/README.md
+++ b/README.md
@@ -11,16 +11,16 @@
 
 ## Usage
 
-Here's a basic example of how to use df-metrics:
+Here's a basic example of how to use df-metrics library:
 ```rust
-use crate::core::definition::AggregateType;
+use crate::core::definition::{AggregateType,TransformationBuilder};
 use crate::metrics::MetricsManager;
 use crate::storage::StorageBackend;
 use arrow::array::{Int32Array, StringArray, Float32Array, RecordBatch};
 use arrow::datatypes::{DataType, Field, Schema};
 use std::sync::Arc;
 
-fn main() {
+async fn main() {
     let col_id = Arc::new(Int32Array::from(vec![1, 2, 3, 4, 5]));
     let col_category = Arc::new(StringArray::from(vec!["a", "a", "b", "b", "c"]));
     let col_value = Arc::new(Float32Array::from(vec![2.0, 3.0, 5.0, 12.3, 9.5]));
@@ -42,7 +42,41 @@ fn main() {
         .execute(vec![record_batch.unwrap()])
         .publish(StorageBackend::Stdout)
         .await
+        .unwrap()
 }
+```
+
+This is another example using the built-in metrics
+
+```rust
+use crate::core::definition::BuiltInMetricsBuilder;
+use crate::metrics::MetricsManager;
+use crate::storage::StorageBackend;
+use arrow::array::{Int32Array, StringArray, Float32Array, RecordBatch};
+use arrow::datatypes::{DataType, Field, Schema};
+use std::sync::Arc;
+
+async fn main() {
+
+    let col_id = Arc::new(Int32Array::from(vec![1, 2, 3, 4, 5]));
+    let col_category = Arc::new(StringArray::from(vec!["a", "a", "b", "b", "c"]));
+    let col_value = Arc::new(Float32Array::from(vec![Some(2.0), None, Some(5.0), Some(12.3), Some(9.5)]));
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Int32, false),
+        Field::new("category", DataType::Utf8, false),
+        Field::new("value", DataType::Float32, true),
+    ]));
+    let record_batch = RecordBatch::try_new(schema.clone(), vec![col_id, col_category, col_value]).unwrap();
+    
+    MetricsManager::default()
+        .transform(BuiltInMetricsBuilder::new().count_null("value", None))
+        .execute(vec![record_batch.unwrap()])
+        .publish(StorageBackend::Stdout)
+        .await
+        .unwrap()
+}
+
+
 ```
 
 ## Contributing

--- a/src/core/computing.rs
+++ b/src/core/computing.rs
@@ -69,7 +69,7 @@ mod test {
 
         let expected_schema = Arc::new(Schema::new(vec![
             Field::new("category", DataType::Utf8, false),
-            Field::new("count(obs_table.value)", DataType::Int64, true),
+            Field::new("value", DataType::Int64, true),
         ]));
 
         let expected_result = vec![

--- a/src/core/parser.rs
+++ b/src/core/parser.rs
@@ -1,8 +1,8 @@
-use crate::core::definition::{AggregateType, Instruction};
+use crate::core::definition::{AggregateType, ExprValue, Instruction};
 use datafusion::common::DataFusionError;
 use datafusion::dataframe::DataFrame;
 use datafusion::functions_aggregate::expr_fn::{avg, count, max, min, sum};
-use datafusion::logical_expr::{col, Expr};
+use datafusion::logical_expr::Expr;
 
 pub async fn parse(
     instructions: &Vec<Instruction>,
@@ -11,11 +11,10 @@ pub async fn parse(
     for instruction in instructions {
         match instruction {
             Instruction::Select(columns) => {
-                let exprs: Vec<Expr> = columns.iter().map(|c| col(c)).collect();
-                dataframe = dataframe.select(exprs)?;
+                dataframe = dataframe.select(columns.to_vec())?;
             }
+            // aggregated instructions are tightly couple to group by
             Instruction::GroupBy(columns) => {
-                let exprs: Vec<Expr> = columns.iter().map(|c| col(c)).collect();
                 if let Some(Instruction::Aggregate(_, _)) = instructions
                     .iter()
                     .find(|i| matches!(i, Instruction::Aggregate(_, _)))
@@ -26,21 +25,21 @@ pub async fn parse(
                             if let Instruction::Aggregate(_, cols) = i {
                                 Some(
                                     cols.iter()
-                                        .map(|c| match i {
+                                        .map(|ExprValue(alias, c)| match i {
                                             Instruction::Aggregate(AggregateType::Sum, _) => {
-                                                sum(col(c))
+                                                sum(c.clone()).alias(alias)
                                             }
                                             Instruction::Aggregate(AggregateType::Avg, _) => {
-                                                avg(col(c))
+                                                avg(c.clone()).alias(alias)
                                             }
                                             Instruction::Aggregate(AggregateType::Min, _) => {
-                                                min(col(c))
+                                                min(c.clone()).alias(alias)
                                             }
                                             Instruction::Aggregate(AggregateType::Max, _) => {
-                                                max(col(c))
+                                                max(c.clone()).alias(alias)
                                             }
                                             Instruction::Aggregate(AggregateType::Count, _) => {
-                                                count(col(c))
+                                                count(c.clone()).alias(alias)
                                             }
                                             _ => unreachable!(),
                                         })
@@ -52,12 +51,15 @@ pub async fn parse(
                         })
                         .flatten()
                         .collect();
-                    dataframe = dataframe.aggregate(exprs, agg_exprs)?;
+                    dataframe = dataframe.aggregate(columns.to_vec(), agg_exprs)?;
                 }
             }
             Instruction::Filter(condition) => {
                 let filter_expr = dataframe.parse_sql_expr(condition)?;
                 dataframe = dataframe.filter(filter_expr)?;
+            }
+            Instruction::Literal(alias, expr) | Instruction::NewCol(alias, expr) => {
+                dataframe = dataframe.with_column(alias, expr.clone())?;
             }
             _ => {}
         }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -49,7 +49,7 @@ impl MetricsManager {
 
 #[cfg(test)]
 mod test {
-    use crate::core::definition::{AggregateType, TransformationBuilder};
+    use crate::core::definition::{AggregateType, BuiltInMetricsBuilder, TransformationBuilder};
     use crate::metrics::MetricsManager;
     use crate::storage::StorageBackend;
     use crate::test::generate_dataset;
@@ -65,6 +65,17 @@ mod test {
                     .group_by(vec!["category"])
                     .build(),
             )
+            .execute(vec![record_batch.unwrap()])
+            .publish(StorageBackend::Stdout)
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_count_null_metrics() {
+        let record_batch = generate_dataset();
+        MetricsManager::default()
+            .transform(BuiltInMetricsBuilder::new().count_null("value", None))
             .execute(vec![record_batch.unwrap()])
             .publish(StorageBackend::Stdout)
             .await

--- a/src/test.rs
+++ b/src/test.rs
@@ -7,7 +7,13 @@ use std::sync::Arc;
 pub fn generate_dataset() -> Result<RecordBatch, ArrowError> {
     let col_id = Arc::new(Int32Array::from(vec![1, 2, 3, 4, 5]));
     let col_category = Arc::new(StringArray::from(vec!["a", "a", "b", "b", "c"]));
-    let col_value = Arc::new(Float32Array::from(vec![2.0, 3.0, 5.0, 12.3, 9.5]));
+    let col_value = Arc::new(Float32Array::from(vec![
+        Some(2.0),
+        None,
+        Some(5.0),
+        Some(12.3),
+        Some(9.5),
+    ]));
     let schem = Arc::new(Schema::new(vec![
         Field::new("id", DataType::Int32, false),
         Field::new("category", DataType::Utf8, false),


### PR DESCRIPTION
closes #17 


This contains the initial implementation of the built-in metrics, specifically for null count. One small caveat is that if you want to generate the same metric for different columns you will need to do multiple executions. We need to implement to unpivot Instruction to add support to multiple columns in a single execution. 